### PR TITLE
Allow uuid 5.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   collection: ^1.17.1
   flutter:
     sdk: flutter
-  uuid: ^3.0.7
+  uuid: ">=3.0.7 <5.0.0"
 
 dev_dependencies:
   dependency_validator: ^3.0.0


### PR DESCRIPTION
The `uuid` package for 5.x changed the constructor parameters. Since these are not used in this package, it's enough to update `pubspec.yaml` to allow `uuid` version 4.x and 5.x.